### PR TITLE
enable cross trigger.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "KiiPlatform/thing-if-iOSSDK" == 0.10.0
+github "KiiPlatform/thing-if-iOSSDK" "cross_thing_trigger"

--- a/SampleProject/CommandTriggerDetailViewController.swift
+++ b/SampleProject/CommandTriggerDetailViewController.swift
@@ -27,14 +27,21 @@ class CommandTriggerDetailViewController: KiiBaseTableViewController, TriggerCom
     @IBOutlet weak var vendorThingIDCell: UITableViewCell!
     @IBOutlet weak var vendorThingIDText: UITextField!
 
+    enum TargetType: String {
+        case NONE = "None"
+        case STANDALONE = "StandaloneThing"
+        case GATEWAY = "Gateway"
+        case ENDNODE = "EndNode"
+    }
+
     var trigger: Trigger?
 
     private var statePredicateToSave: StatePredicate?
     private var commandStructToSave: CommandStruct?
     private var commandTarget: Target?
 
-    private let commandTargetList: [String] = ["None", "StandaloneThing", "Gateway", "EndNode"]
-    private var commandTargetSelected: Int = 0
+    private let commandTargetList: [TargetType] = [.NONE, .STANDALONE, .GATEWAY, .ENDNODE]
+    private var commandTargetSelected: TargetType = .NONE
 
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
@@ -124,13 +131,13 @@ class CommandTriggerDetailViewController: KiiBaseTableViewController, TriggerCom
                     let thingID = thingIDText.text ?? ""
                     let vendorThingID = vendorThingIDText.text ?? ""
                     switch commandTargetSelected {
-                    case 1:
+                    case .STANDALONE:
                         commandTarget = StandaloneThing(thingID: thingID, vendorThingID: vendorThingID)
                         break
-                    case 2:
+                    case .GATEWAY:
                         commandTarget = Gateway(thingID: thingID, vendorThingID: vendorThingID)
                         break
-                    case 3:
+                    case .ENDNODE:
                         commandTarget = EndNode(thingID: thingID, vendorThingID: vendorThingID)
                         break
                     default:
@@ -169,17 +176,18 @@ class CommandTriggerDetailViewController: KiiBaseTableViewController, TriggerCom
     }
 
     func pickerView(pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        return self.commandTargetList[row]
+        return self.commandTargetList[row].rawValue
     }
 
     func pickerView(pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        if row == 0 {
+        let type = self.commandTargetList[row]
+        if type == .NONE {
             self.thingIDCell.hidden = true
             self.vendorThingIDCell.hidden = true
         } else {
             self.thingIDCell.hidden = false
             self.vendorThingIDCell.hidden = false
         }
-        self.commandTargetSelected = row
+        self.commandTargetSelected = type
     }
 }

--- a/SampleProject/CommandTriggerDetailViewController.swift
+++ b/SampleProject/CommandTriggerDetailViewController.swift
@@ -15,16 +15,26 @@ struct CommandStruct {
     let actions: [Dictionary<String, AnyObject>]!
 }
 
-class CommandTriggerDetailViewController: KiiBaseTableViewController, TriggerCommandEditViewControllerDelegate, StatesPredicateViewControllerDelegate {
+class CommandTriggerDetailViewController: KiiBaseTableViewController, TriggerCommandEditViewControllerDelegate, StatesPredicateViewControllerDelegate, UIPickerViewDataSource, UIPickerViewDelegate {
 
     @IBOutlet weak var commandDetailLabel: UILabel!
 
     @IBOutlet weak var statePredicateDetailLabel: UILabel!
 
+    @IBOutlet weak var crossTriggerCell: UITableViewCell!
+    @IBOutlet weak var thingIDCell: UITableViewCell!
+    @IBOutlet weak var thingIDText: UITextField!
+    @IBOutlet weak var vendorThingIDCell: UITableViewCell!
+    @IBOutlet weak var vendorThingIDText: UITextField!
+
     var trigger: Trigger?
 
     private var statePredicateToSave: StatePredicate?
     private var commandStructToSave: CommandStruct?
+    private var commandTarget: Target?
+
+    private let commandTargetList: [String] = ["None", "StandaloneThing", "Gateway", "EndNode"]
+    private var commandTargetSelected: Int = 0
 
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
@@ -60,6 +70,14 @@ class CommandTriggerDetailViewController: KiiBaseTableViewController, TriggerCom
         if trigger != nil {
             commandStructToSave = CommandStruct(schemaName: self.trigger!.command!.schemaName, schemaVersion: self.trigger!.command!.schemaVersion, actions: self.trigger!.command!.actions)
         }
+        // for UI.
+        if trigger != nil {
+            self.crossTriggerCell.hidden = true
+        } else {
+            self.crossTriggerCell.hidden = false
+        }
+        self.thingIDCell.hidden = true
+        self.vendorThingIDCell.hidden = true
     }
 
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
@@ -103,7 +121,23 @@ class CommandTriggerDetailViewController: KiiBaseTableViewController, TriggerCom
                 })
             }else {
                 if statePredicateToSave != nil {
-                    iotAPI!.postNewTrigger(commandStructToSave!.schemaName, schemaVersion: commandStructToSave!.schemaVersion, actions: commandStructToSave!.actions, predicate: statePredicateToSave!, completionHandler: { (newTrigger, error) -> Void in
+                    let thingID = thingIDText.text ?? ""
+                    let vendorThingID = vendorThingIDText.text ?? ""
+                    switch commandTargetSelected {
+                    case 1:
+                        commandTarget = StandaloneThing(thingID: thingID, vendorThingID: vendorThingID)
+                        break
+                    case 2:
+                        commandTarget = Gateway(thingID: thingID, vendorThingID: vendorThingID)
+                        break
+                    case 3:
+                        commandTarget = EndNode(thingID: thingID, vendorThingID: vendorThingID)
+                        break
+                    default:
+                        commandTarget = nil
+                        break
+                    }
+                    iotAPI!.postNewTrigger(commandStructToSave!.schemaName, schemaVersion: commandStructToSave!.schemaVersion, actions: commandStructToSave!.actions, predicate: statePredicateToSave!, target: commandTarget, completionHandler: { (newTrigger, error) -> Void in
                         if newTrigger != nil {
                             self.trigger = newTrigger
                         }else {
@@ -125,4 +159,27 @@ class CommandTriggerDetailViewController: KiiBaseTableViewController, TriggerCom
         self.statePredicateToSave = newPredicate
     }
 
+    //MARK: Picker delegation methods
+    func numberOfComponentsInPickerView(pickerView: UIPickerView) -> Int {
+        return 1
+    }
+
+    func pickerView(pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return self.commandTargetList.count
+    }
+
+    func pickerView(pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        return self.commandTargetList[row]
+    }
+
+    func pickerView(pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        if row == 0 {
+            self.thingIDCell.hidden = true
+            self.vendorThingIDCell.hidden = true
+        } else {
+            self.thingIDCell.hidden = false
+            self.vendorThingIDCell.hidden = false
+        }
+        self.commandTargetSelected = row
+    }
 }

--- a/SampleProject/Triggers.storyboard
+++ b/SampleProject/Triggers.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="14F1605" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="0Lb-3u-x5U">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="0Lb-3u-x5U">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -169,6 +169,71 @@
                                             </segue>
                                         </connections>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="CrossTriggerCell" rowHeight="99" id="bON-iY-vSc">
+                                        <rect key="frame" x="0.0" y="239" width="600" height="99"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="bON-iY-vSc" id="3Db-N6-tM5">
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="98"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Cross Trigger:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2fI-gA-npa">
+                                                    <rect key="frame" x="18" y="41" width="130" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <pickerView contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fRs-vj-gFO">
+                                                    <rect key="frame" x="150" y="8" width="228" height="87"/>
+                                                    <connections>
+                                                        <outlet property="dataSource" destination="UaW-KF-Oas" id="UPE-SP-f2b"/>
+                                                        <outlet property="delegate" destination="UaW-KF-Oas" id="LIc-0P-dM3"/>
+                                                    </connections>
+                                                </pickerView>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="ThingIDCell" id="7JD-T1-gQ2">
+                                        <rect key="frame" x="0.0" y="338" width="600" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="7JD-T1-gQ2" id="HvV-hh-qRb">
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Thing ID:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Quw-Wd-VQ6">
+                                                    <rect key="frame" x="17" y="11" width="130" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="he3-ln-g8K">
+                                                    <rect key="frame" x="92" y="7" width="301" height="30"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                </textField>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="VendorThingIDCell" id="4aF-H9-Cdu">
+                                        <rect key="frame" x="0.0" y="382" width="600" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="4aF-H9-Cdu" id="l0J-eT-D5Y">
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Vendor Thing ID:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wzo-N4-ipy">
+                                                    <rect key="frame" x="16" y="11" width="130" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="TlH-CP-3ZF">
+                                                    <rect key="frame" x="148" y="7" width="249" height="30"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                </textField>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                         </sections>
@@ -186,7 +251,12 @@
                     </navigationItem>
                     <connections>
                         <outlet property="commandDetailLabel" destination="QS0-Cq-uY5" id="Nc2-nv-uV3"/>
+                        <outlet property="crossTriggerCell" destination="bON-iY-vSc" id="AvC-Hc-SaQ"/>
                         <outlet property="statePredicateDetailLabel" destination="1yj-99-SFi" id="dVv-rG-G56"/>
+                        <outlet property="thingIDCell" destination="7JD-T1-gQ2" id="HfQ-2I-wVq"/>
+                        <outlet property="thingIDText" destination="he3-ln-g8K" id="JVS-K6-nvJ"/>
+                        <outlet property="vendorThingIDCell" destination="4aF-H9-Cdu" id="v9y-r3-TPZ"/>
+                        <outlet property="vendorThingIDText" destination="TlH-CP-3ZF" id="FVs-q2-6Gr"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="VVE-qf-WCE" userLabel="First Responder" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
Command向けの新しいTrigger作成画面にターゲットタイプ(選択無し含む)、ThingID、VendorThingIDを設定させるUIを追加し、ターゲットタイプを設定した場合は各値に従ってターゲットを作成しpostNewTrigger呼び出し時に渡すように修正しました。

関連: [thing-if-iOSSDK#148](https://github.com/KiiPlatform/thing-if-iOSSDK/pull/148)
