### PR TITLE
Refactor command trigger view

### DIFF
--- a/SampleProject/CommandTriggerDetailViewController.swift
+++ b/SampleProject/CommandTriggerDetailViewController.swift
@@ -21,7 +21,6 @@ class CommandTriggerDetailViewController: KiiBaseTableViewController, TriggerCom
 
     @IBOutlet weak var statePredicateDetailLabel: UILabel!
 
-    var trigger: Trigger?
     private var triggerID: String?
     private var statePredicateToSave: StatePredicate?
     private var commandStructToSave: CommandStruct?
@@ -83,10 +82,10 @@ class CommandTriggerDetailViewController: KiiBaseTableViewController, TriggerCom
         self.navigationController?.popViewControllerAnimated(true)
     }
     func saveTrigger() {
-        if let api = iotAPI,
-           let command = self.commandStructToSave,
-           let predicate = self.statePredicateToSave {
+        if let api = iotAPI {
             if let triggerID = self.triggerID {
+                let command = self.commandStructToSave!
+                let predicate = self.statePredicateToSave!
                 api.patchTrigger(
                   triggerID,
                   triggeredCommandForm: TriggeredCommandForm(
@@ -96,13 +95,12 @@ class CommandTriggerDetailViewController: KiiBaseTableViewController, TriggerCom
                   predicate: predicate,
                   options: self.options,
                   completionHandler: { (updatedTrigger, error) -> Void in
-                    if updatedTrigger != nil {
-                        self.trigger = updatedTrigger
-                    }else {
+                    if error != nil {
                         self.showAlert("Update Trigger Failed", error: error, completion: nil)
                     }
                 })
-            }else {
+            } else if let command = self.commandStructToSave,
+                      let predicate = self.statePredicateToSave {
                 api.postNewTrigger(
                   TriggeredCommandForm(
                     schemaName: command.schemaName,
@@ -111,9 +109,7 @@ class CommandTriggerDetailViewController: KiiBaseTableViewController, TriggerCom
                   predicate: predicate,
                   options: self.options,
                   completionHandler: { (newTrigger, error) -> Void in
-                      if newTrigger != nil {
-                          self.trigger = newTrigger
-                      }else {
+                      if error != nil {
                           self.showAlert("Create Trigger Failed", error: error, completion: nil)
                       }
                   })

--- a/SampleProject/TriggerListViewController.swift
+++ b/SampleProject/TriggerListViewController.swift
@@ -272,13 +272,10 @@ class TriggerListViewController: KiiBaseTableViewController, UIPickerViewDataSou
             if let triggerDetailVC = segue.destinationViewController as? CommandTriggerDetailViewController {
                 if let selectedCell = sender as? UITableViewCell {
                     if let indexPath = self.tableView.indexPathForCell(selectedCell){
-                        var selectedTrigger: Trigger
                         if indexPath.section == 0 {
-                            selectedTrigger = self.commandTriggers[indexPath.row]
-                        } else {
-                            selectedTrigger = self.serverCodeTriggers[indexPath.row]
+                            triggerDetailVC.setup(
+                              self.commandTriggers[indexPath.row]);
                         }
-                        triggerDetailVC.trigger = selectedTrigger
                     }
                 }
             }


### PR DESCRIPTION
現状のCommand Triggerのviewはデータソースを2系統持っています。
viewを作成する際に渡されるtriggerと、修正されたデータを持つCommandStructなどのフィールド群です。

データソースを2つ持つのはコードを理解しづらいものにします。このため、triggerを削除してデータを1系統にまとめるよう修正しました。

Related PR: #19
