### PR TITLE
Bugs are fixed.

### DIFF
--- a/SampleProject/TriggerCommandEditViewController.swift
+++ b/SampleProject/TriggerCommandEditViewController.swift
@@ -48,8 +48,8 @@ class TriggerCommandEditViewController: CommandEditViewController {
                 if let data = try? NSJSONSerialization.dataWithJSONObject(
                      metadata, options: .PrettyPrinted) {
                     metadataSection.items.append(
-                      NSString(data:data,
-                               encoding:NSUTF8StringEncoding)! as String)
+                      String(data:data,
+                             encoding:NSUTF8StringEncoding)!)
                 }
             }
         }
@@ -140,11 +140,27 @@ class TriggerCommandEditViewController: CommandEditViewController {
         } else {
             schemaVersion = nil
         }
-        let targetID: String? =
-          (self.view.viewWithTag(202) as? UITextField)?.text
-        let title: String? = (self.view.viewWithTag(203) as? UITextField)?.text
-        let description: String? =
-          (self.view.viewWithTag(204) as? UITextView)?.text
+        let targetID: String?
+        if let text = (self.view.viewWithTag(202) as? UITextField)?.text
+          where !text.isEmpty {
+            targetID = text
+        } else {
+            targetID = nil
+        }
+        let title: String?
+        if let text = (self.view.viewWithTag(203) as? UITextField)?.text
+          where !text.isEmpty {
+            title = text
+        } else {
+            title = nil
+        }
+        let description: String?
+        if let text = (self.view.viewWithTag(204) as? UITextView)?.text
+          where !text.isEmpty {
+            description = text
+        } else {
+            description = nil
+        }
         let metadata: Dictionary<String, AnyObject>?
         if let text = (self.view.viewWithTag(205) as? UITextView)?.text {
             metadata = try? NSJSONSerialization.JSONObjectWithData(

--- a/SampleProject/TriggerOptionsViewController.swift
+++ b/SampleProject/TriggerOptionsViewController.swift
@@ -40,7 +40,7 @@ class TriggerOptionsViewController: KiiBaseTableViewController {
         }
     }
 
-    @IBAction func tapSaveCommand(sender: AnyObject) {
+    @IBAction func tapSaveTriggerOptions(sender: AnyObject) {
         var metadata: Dictionary<String, AnyObject>?
         if let text = self.metadataField.text {
             metadata = try? NSJSONSerialization.JSONObjectWithData(

--- a/SampleProject/Triggers.storyboard
+++ b/SampleProject/Triggers.storyboard
@@ -541,7 +541,7 @@
                     <navigationItem key="navigationItem" title="Trigger Options" id="Rxh-Yh-WeA">
                         <barButtonItem key="rightBarButtonItem" title="Save" id="sVu-ya-UXS">
                             <connections>
-                                <action selector="tapSaveCommand:" destination="ZCX-fY-BMw" id="RlZ-0A-OdT"/>
+                                <action selector="tapSaveTriggerOptions:" destination="ZCX-fY-BMw" id="fkV-Oa-CzT"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>


### PR DESCRIPTION
最終確認をしたところ、見つかったバグを修正しました。

Commandのtarget ID、title、descriptionのviewから値をとる際にバグがありました。空のtext fieldから文字列を取り出した場合にnilになると思っていたのですが、空文字列でした。このため、postNewTriggerの際に、thing idなどに想定外の値が設定されていました。

バグではないのですが、TriggerOptionsのメソッド名を一つ修正しました。`tapSaveCommand`という名前だったのですが、正しくは`tapSaveTriggerOptions`なので、そのようにしました。

Related PR: #19 
