### PR TITLE
Sample application adapts thing-if iOSSDK v0.13.1 with CocoaPods.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "KiiPlatform/thing-if-iOSSDK" "develop"
+github "KiiPlatform/thing-if-iOSSDK" >= 0.13.1

--- a/Podfile
+++ b/Podfile
@@ -7,5 +7,5 @@ use_frameworks!
 
 target 'SampleProject' do
 pod 'KiiCloud'
-# pod 'ThingIFSDK'
+pod 'ThingIFSDK'
 end

--- a/SampleProject-Bridging-Header.h
+++ b/SampleProject-Bridging-Header.h
@@ -1,5 +1,0 @@
-//
-//  Use this file to import your target's public headers that you would like to expose to Swift.
-//
-
-#import <KiiSDK/KiiSDK.h>

--- a/SampleProject-Bridging-Header.h
+++ b/SampleProject-Bridging-Header.h
@@ -2,4 +2,4 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
-#import <KiiSDK/KiiSDK-Bridging-Header.h>
+#import <KiiSDK/KiiSDK.h>

--- a/SampleProject.xcodeproj/project.pbxproj
+++ b/SampleProject.xcodeproj/project.pbxproj
@@ -87,7 +87,6 @@
 		7D45C0791B91E84500378D6D /* IntervalStatusTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntervalStatusTableViewCell.swift; sourceTree = "<group>"; };
 		7D783E491B85CD9100543A09 /* SampleProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SampleProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7D783E4C1B87157F00543A09 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
-		7D783E4F1B8715E500543A09 /* SampleProject-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SampleProject-Bridging-Header.h"; sourceTree = "<group>"; };
 		7D8FAB4C1B8EB00100D57F8E /* CommandEditViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandEditViewController.swift; sourceTree = "<group>"; };
 		7D8FAB501B8EC26900D57F8E /* TriggerCommandEditViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TriggerCommandEditViewController.swift; sourceTree = "<group>"; };
 		7D96858B1B8AF3C90017CA7D /* LoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
@@ -152,7 +151,6 @@
 				7D783E4E1B87159400543A09 /* frameworks */,
 				7D108AD91B7210C8006EA12B /* SampleProject */,
 				7D783E491B85CD9100543A09 /* SampleProject.app */,
-				7D783E4F1B8715E500543A09 /* SampleProject-Bridging-Header.h */,
 				770FA5D2802D7132F870F3A9 /* Pods */,
 				42632332CB0F7552608D41C8 /* Frameworks */,
 			);
@@ -558,7 +556,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kii.SampleProject;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				SWIFT_OBJC_BRIDGING_HEADER = "SampleProject-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -587,7 +584,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kii.SampleProject;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				SWIFT_OBJC_BRIDGING_HEADER = "SampleProject-Bridging-Header.h";
 				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 1;
 			};

--- a/SampleProject.xcodeproj/project.pbxproj
+++ b/SampleProject.xcodeproj/project.pbxproj
@@ -45,8 +45,6 @@
 		A5C99DD51C85A5CD00FC83FE /* TriggerServerCodeParameterEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C99DD41C85A5CD00FC83FE /* TriggerServerCodeParameterEditViewController.swift */; };
 		A5F53FB71C8042F400B713EE /* ServerCodeTriggerDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F53FB61C8042F400B713EE /* ServerCodeTriggerDetailViewController.swift */; };
 		B65736891DB0CED00018C27C /* TriggerOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65736881DB0CECF0018C27C /* TriggerOptionsViewController.swift */; };
-		B6DE17DF1DAE115C006B4558 /* ThingIFSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B6DE17DE1DAE115C006B4558 /* ThingIFSDK.framework */; };
-		B6DE17E11DAE1183006B4558 /* ThingIFSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B6DE17E01DAE1183006B4558 /* ThingIFSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D5351AA91B8ED6D900E55807 /* Notifications.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D5351AA71B8ED6D900E55807 /* Notifications.storyboard */; };
 		D5351AAB1B8EDA8900E55807 /* NotificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5351AAA1B8EDA8900E55807 /* NotificationViewController.swift */; };
 		D5A799A41B8EFC2B00F029F5 /* NotificationSettingVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A799A31B8EFC2B00F029F5 /* NotificationSettingVC.swift */; };
@@ -59,7 +57,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				B6DE17E11DAE1183006B4558 /* ThingIFSDK.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -122,7 +119,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B6DE17DF1DAE115C006B4558 /* ThingIFSDK.framework in Frameworks */,
 				7D783E4D1B87157F00543A09 /* libsqlite3.tbd in Frameworks */,
 				32F0D076E95C4ECA320FABEC /* Pods_SampleProject.framework in Frameworks */,
 			);
@@ -264,13 +260,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7D108AFF1B7210C8006EA12B /* Build configuration list for PBXNativeTarget "SampleProject" */;
 			buildPhases = (
-				E6D8ECD25D795C6B9328864A /* Check Pods Manifest.lock */,
+				E6D8ECD25D795C6B9328864A /* [CP] Check Pods Manifest.lock */,
 				7D108AD31B7210C8006EA12B /* Sources */,
 				7D108AD41B7210C8006EA12B /* Frameworks */,
 				7D108AD51B7210C8006EA12B /* Resources */,
-				3BCCB60907E59D3A2972C70D /* Copy Pods Resources */,
+				3BCCB60907E59D3A2972C70D /* [CP] Copy Pods Resources */,
 				7DA9D2041BD4E58C0092B4BC /* Embed Frameworks */,
-				CDCDB44EBE039D76032B8571 /* Embed Pods Frameworks */,
+				CDCDB44EBE039D76032B8571 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -344,14 +340,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3BCCB60907E59D3A2972C70D /* Copy Pods Resources */ = {
+		3BCCB60907E59D3A2972C70D /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -359,14 +355,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SampleProject/Pods-SampleProject-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		CDCDB44EBE039D76032B8571 /* Embed Pods Frameworks */ = {
+		CDCDB44EBE039D76032B8571 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -374,19 +370,19 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SampleProject/Pods-SampleProject-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E6D8ECD25D795C6B9328864A /* Check Pods Manifest.lock */ = {
+		E6D8ECD25D795C6B9328864A /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/SampleProject/AppDelegate.swift
+++ b/SampleProject/AppDelegate.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Kii Corporation. All rights reserved.
 //
 
+import KiiSDK
 import UIKit
 import ThingIFSDK
 

--- a/SampleProject/LoginViewController.swift
+++ b/SampleProject/LoginViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Yongping on 8/24/15.
 //  Copyright © 2015 Kii Corporation. All rights reserved.
 //
+import KiiSDK
 import UIKit
 import ThingIFSDK
 


### PR DESCRIPTION
v0.13.1でのテストを行うために、cocoapodsの設定などを変更していたものを元に戻しました。
修正内容は
- Podでthing-if iOSSDKを取得できるよう、Podfileを修正。
- XCodeプロジェクト上で、carthageのthing-if iOSSDKを使うためにしていた設定を削除
- carthageの取得バージョンをv0.13.1以上に変更

加えて、KiiSDKがv2.6.3に変更されたのに伴う、以下の修正を行いました。
- `SampleProject-Bridging-Header.h` で呼び出すヘッダファイルを`KiiSDK/KiiSDK.h`に変更
