### PR TITLE
Implicitly casting algorithm is changed in swift 3.0

### DIFF
--- a/SampleProject/AndOrClauseViewController.swift
+++ b/SampleProject/AndOrClauseViewController.swift
@@ -83,7 +83,7 @@ class AndOrClauseViewController: KiiBaseTableViewController, UIPickerViewDataSou
             return tableView.dequeueReusableCell(withIdentifier: "NewClauseButtonCell", for: indexPath)
         }else {
             let clause = subClauses[indexPath.row]
-            let clauseDict = clause.toNSDictionary()
+            let clauseDict = clause.toNSDictionary() as! [ String : Any ]
             let clauseType = ClauseType.getClauseType(clause)!
 
             var cell: UITableViewCell!
@@ -95,7 +95,7 @@ class AndOrClauseViewController: KiiBaseTableViewController, UIPickerViewDataSou
                 let status = ClauseHelper.getStatusFromClause(clause)
                 let statusType = schema!.getStatusType(status)!
                 // only for int and bool value
-                var singleValue: AnyObject?
+                var singleValue: Any?
                 var lowerLimitValue: Int?
                 var upperLimitValue: Int?
 

--- a/SampleProject/AndOrClauseViewController.swift
+++ b/SampleProject/AndOrClauseViewController.swift
@@ -347,7 +347,7 @@ class AndOrClauseViewController: KiiBaseTableViewController, UIPickerViewDataSou
         }
     }
 
-    func setStatus(_ sender: UITableViewCell, value: AnyObject) {
+    func setStatus(_ sender: UITableViewCell, value: Any) {
         let indexPath = self.tableView.indexPath(for: sender)!
         let clause = subClauses[indexPath.row]
         let status = ClauseHelper.getStatusFromClause(clause)

--- a/SampleProject/ClauseHelper.swift
+++ b/SampleProject/ClauseHelper.swift
@@ -49,7 +49,7 @@ enum ClauseType: String {
         }else if clause is NotEqualsClause {
             return ClauseType.NotEquals
         } else if clause is RangeClause {
-            let nsdict = clause.toNSDictionary()
+            let nsdict = clause.toNSDictionary() as! [ String : Any ]
             if let _ = nsdict["lowerLimit"], let _ = nsdict["upperLimit"], let lowerIncluded = nsdict["lowerIncluded"] as? Bool, let upperIncluded = nsdict["upperIncluded"] as? Bool{
                 if lowerIncluded && upperIncluded {
                     return ClauseType.BothClose
@@ -191,7 +191,7 @@ class ClauseHelper {
     }
 
     static func getStatusFromClause(_ clause: Clause) -> String {
-        let clauseDict = clause.toNSDictionary()
+        let clauseDict = clause.toNSDictionary() as! [ String : Any ]
         let clauseType = ClauseType.getClauseType(clause)!
 
         if clauseType != ClauseType.NotEquals {

--- a/SampleProject/ClauseHelper.swift
+++ b/SampleProject/ClauseHelper.swift
@@ -236,7 +236,7 @@ class ClauseHelper {
         return newClause
     }
 
-    static func getNewClause(_ clause: Clause, singleValue: AnyObject, statusSchema: StatusSchema) -> Clause?{
+    static func getNewClause(_ clause: Clause, singleValue: Any, statusSchema: StatusSchema) -> Clause?{
         var newClause: Clause?
         let status = statusSchema.name
         if let clauseType = ClauseType.getClauseType(clause), let statusType = statusSchema.type {

--- a/SampleProject/CommandEditViewController.swift
+++ b/SampleProject/CommandEditViewController.swift
@@ -302,7 +302,7 @@ class CommandEditViewController: KiiBaseTableViewController, UIPickerViewDataSou
         self.selectedActionName = actionSchemasToSelect[row-1]
     }
 
-    func setStatus(_ sender: UITableViewCell, value: AnyObject) {
+    func setStatus(_ sender: UITableViewCell, value: Any) {
         if let selectedIndexPath = self.tableView.indexPath(for: sender) {
             var selectedAction = sections[selectedIndexPath.section].items[selectedIndexPath.row] as? ActionStruct
             if  selectedAction != nil {

--- a/SampleProject/CommandViewController.swift
+++ b/SampleProject/CommandViewController.swift
@@ -12,13 +12,13 @@ import ThingIFSDK
 extension CommandState {
     public func toString() -> String {
         switch self {
-        case .DELIVERED:
+        case .delivered:
             return "DELIVERED"
-        case .DONE:
+        case .done:
             return "DONE"
-        case .INCOMPLETE:
+        case .incomplete:
             return "INCOMPLETE"
-        case .SENDING:
+        case .sending:
             return "SENDING"
         }
     }

--- a/SampleProject/CommandsListViewController.swift
+++ b/SampleProject/CommandsListViewController.swift
@@ -15,13 +15,13 @@ struct CommandsSection {
     init(state: CommandState, commands: [Command]) {
         self.commands = commands
         switch state {
-        case .DELIVERED:
+        case .delivered:
             self.state = "DELIVERED"
-        case .DONE:
+        case .done:
             self.state = "DONE"
-        case .INCOMPLETE:
+        case .incomplete:
             self.state = "INCOMPLETE"
-        case .SENDING:
+        case .sending:
             self.state = "SENDING"
         }
     }

--- a/SampleProject/KiiBaseTableViewController.swift
+++ b/SampleProject/KiiBaseTableViewController.swift
@@ -59,15 +59,15 @@ class KiiBaseTableViewController: UITableViewController {
         var errorString: String?
         if error != nil {
             switch error! {
-            case .CONNECTION:
+            case .connection:
                 errorString = "CONNECTION"
-            case .ERROR_RESPONSE(let errorResponse):
+            case .error_RESPONSE(let errorResponse):
                 errorString = "{statusCode: \(errorResponse.httpStatusCode), errorCode: \(errorResponse.errorCode), message: \(errorResponse.errorMessage)}"
-            case .JSON_PARSE_ERROR:
+            case .json_PARSE_ERROR:
                 errorString = "JSON_PARSE_ERROR"
-            case .PUSH_NOT_AVAILABLE:
+            case .push_NOT_AVAILABLE:
                 errorString = "PUSH_NOT_AVAILABLE"
-            case .UNSUPPORTED_ERROR:
+            case .unsupported_ERROR:
                 errorString = "UNSUPPORTED_ERROR"
             default:
                 break

--- a/SampleProject/StatesPredicateViewController.swift
+++ b/SampleProject/StatesPredicateViewController.swift
@@ -428,7 +428,7 @@ class StatesPredicateViewController: KiiBaseTableViewController, UIPickerViewDat
     }
 
 
-    func setStatus(_ sender: UITableViewCell, value: AnyObject) {
+    func setStatus(_ sender: UITableViewCell, value: Any) {
         let indexPath = self.tableView.indexPath(for: sender)!
         var section = sections[indexPath.section]
         let clause = section.items[indexPath.row] as! Clause

--- a/SampleProject/StatesPredicateViewController.swift
+++ b/SampleProject/StatesPredicateViewController.swift
@@ -139,7 +139,7 @@ class StatesPredicateViewController: KiiBaseTableViewController, UIPickerViewDat
                  return tableView.dequeueReusableCell(withIdentifier: "NewClauseButtonCell", for: indexPath)
             }else {
                 let clause = section.items[0] as! Clause
-                let clauseDict = clause.toNSDictionary()
+                let clauseDict = clause.toNSDictionary() as! [ String : Any ]
                 let clauseType = ClauseType.getClauseType(clause)!
 
                 var cell: UITableViewCell!
@@ -149,7 +149,7 @@ class StatesPredicateViewController: KiiBaseTableViewController, UIPickerViewDat
                     cell.textLabel?.text = "\(clauseType.rawValue) Clause"
                 }else {
                     // only for int and bool value
-                    var singleValue: AnyObject?
+                    var singleValue: Any?
                     var lowerLimitValue: Int?
                     var upperLimitValue: Int?
                     let status = ClauseHelper.getStatusFromClause(clause)

--- a/SampleProject/Views/StatusNumberTypeTableViewCell.swift
+++ b/SampleProject/Views/StatusNumberTypeTableViewCell.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 protocol StatusTableViewCellDelegate {
-    func setStatus(_ sender: UITableViewCell, value: AnyObject)
+    func setStatus(_ sender: UITableViewCell, value: Any)
 }
 
 class StatusIntTypeTableViewCell: UITableViewCell {


### PR DESCRIPTION
This PR is not buildable. This is a part of migration of swift 3.0.

This PR contains following fixes:

  * `NSDictionary` is casted to `[ String : Any]` (b800981)

     In swift 3.0, We can not access item of `NSDictionary` with `["name"]` notation. I guess automatic casting algorithm is changed form swift 3.0.
     I want to investigate specification changes in [this site](https://github.com/apple/swift-evolution) to clear what was done, but this is out of scope. So I will investigate it later :)

  * AnyObject is changed to Any (5e605b0)

    Before swift 3.0 String, Bool, Int etc can be implicitly casted to AnyObject, After 3.0 they can be implicitly casted to Any.

  * Name of enumeration elements are changed (9d9efbf)

    In KiiPlatform/thing-if-iOSSDK#188, We have converted thing-if-iOSSDK to migrate swift 3.0. As a result, name of enumeration element changed.

Related PR: #31 
