### PR TITLE
Change anyobject

### DIFF
--- a/SampleProject/CommandEditViewController.swift
+++ b/SampleProject/CommandEditViewController.swift
@@ -43,7 +43,7 @@ class CommandEditViewController: KiiBaseTableViewController, UIPickerViewDataSou
             // construct actionsItems
             for actionDict in commandStruct!.actions {
                 if actionDict.keys.count > 0 {
-                    let actionNameKey = Array(actionDict.keys)[0]
+                    let actionNameKey = (Array(actionDict.keys) as! [String])[0]
                     if let actionSchema = schema?.getActionSchema(actionNameKey) {
                         if let actionCellData = ActionStruct(actionSchema: actionSchema, actionDict: actionDict) {
                             actionItems.append(actionCellData)

--- a/SampleProject/CommandEditViewController.swift
+++ b/SampleProject/CommandEditViewController.swift
@@ -253,7 +253,7 @@ class CommandEditViewController: KiiBaseTableViewController, UIPickerViewDataSou
             if let actionSchema = schema?.getActionSchema(selectedActionName) {
                 if let statusType = schema!.getStatusType(actionSchema.status.name) {
 
-                    var defaultedValue: AnyObject?
+                    var defaultedValue: Any?
                     switch statusType {
                     case .BoolType:
                         defaultedValue = false

--- a/SampleProject/CommandNewViewController.swift
+++ b/SampleProject/CommandNewViewController.swift
@@ -21,7 +21,7 @@ class CommandNewViewController: CommandEditViewController {
             self.uploadButton.isEnabled = false
 
             // generate actions array
-            var actions = [Dictionary<String, AnyObject>]()
+            var actions = [Dictionary<String, Any>]()
             if let actionsItems = sections[2].items {
                 for actionItem in actionsItems {
                     if let actionCellData = actionItem as? ActionStruct {

--- a/SampleProject/CommandTriggerDetailViewController.swift
+++ b/SampleProject/CommandTriggerDetailViewController.swift
@@ -12,11 +12,11 @@ import ThingIFSDK
 struct CommandStruct {
     let schemaName: String!
     let schemaVersion: Int!
-    let actions: [Dictionary<String, AnyObject>]!
+    let actions: [Dictionary<String, Any>]!
     let targetID: String?
     let title: String?
     let commandDescription: String?
-    let metadata: Dictionary<String, AnyObject>?
+    let metadata: Dictionary<String, Any>?
 }
 
 class CommandTriggerDetailViewController: KiiBaseTableViewController, TriggerCommandEditViewControllerDelegate, StatesPredicateViewControllerDelegate, TriggerOptionsViewControllerDelegate {
@@ -36,11 +36,11 @@ class CommandTriggerDetailViewController: KiiBaseTableViewController, TriggerCom
         self.commandStructToSave = CommandStruct(
           schemaName: command.schemaName,
           schemaVersion: command.schemaVersion,
-          actions: command.actions as [Dictionary<String, AnyObject>]!,
+          actions: command.actions,
           targetID: command.targetID.id,
           title: command.title,
           commandDescription: command.commandDescription,
-          metadata: command.metadata as Dictionary<String, AnyObject>?)
+          metadata: command.metadata)
         self.statePredicateToSave = trigger.predicate as? StatePredicate
         if trigger.title != nil ||
              trigger.triggerDescription != nil ||
@@ -145,11 +145,11 @@ class CommandTriggerDetailViewController: KiiBaseTableViewController, TriggerCom
     func saveCommands(
       _ schemaName: String,
       schemaVersion: Int,
-      actions: [Dictionary<String, AnyObject>],
+      actions: [Dictionary<String, Any>],
       targetID: String?,
       title: String?,
       commandDescription: String?,
-      metadata: Dictionary<String, AnyObject>?) {
+      metadata: Dictionary<String, Any>?) {
         self.commandStructToSave = CommandStruct(
           schemaName: schemaName,
           schemaVersion: schemaVersion,
@@ -166,7 +166,7 @@ class CommandTriggerDetailViewController: KiiBaseTableViewController, TriggerCom
 
     func saveTriggerOptions(_ title: String?,
                             description: String?,
-                            metadata: Dictionary<String, AnyObject>?)
+                            metadata: Dictionary<String, Any>?)
     {
         if title != nil || description != nil || metadata != nil {
             self.options = TriggerOptions(title: title,

--- a/SampleProject/CommandViewController.swift
+++ b/SampleProject/CommandViewController.swift
@@ -79,7 +79,7 @@ class CommandViewController: KiiBaseTableViewController {
             let cell = tableView.dequeueReusableCell(withIdentifier: "ActionItemCell", for: indexPath)
             let action = sections[indexPath.section].items[indexPath.row] as! Dictionary<String, AnyObject>
             if action.keys.count > 0 {
-                let actionKey: String = Array(action.keys)[0]
+                let actionKey: String = (Array(action.keys) as! [String])[0]
                 cell.textLabel?.text = actionKey
                 var actionString = ""
                 if let actionDict = action[actionKey] as? Dictionary<String, AnyObject> {

--- a/SampleProject/CommandViewController.swift
+++ b/SampleProject/CommandViewController.swift
@@ -26,7 +26,7 @@ extension CommandState {
 class CommandViewController: KiiBaseTableViewController {
     struct SectionStruct {
         let headerTitle: String!
-        var items: [AnyObject]!
+        var items: [Any]!
     }
 
     var command: Command?
@@ -77,12 +77,12 @@ class CommandViewController: KiiBaseTableViewController {
 
         if sections[indexPath.section].headerTitle == "Actions"  || sections[indexPath.section].headerTitle == "ActionResults" {
             let cell = tableView.dequeueReusableCell(withIdentifier: "ActionItemCell", for: indexPath)
-            let action = sections[indexPath.section].items[indexPath.row] as! Dictionary<String, AnyObject>
+            let action = sections[indexPath.section].items[indexPath.row] as! Dictionary<String, Any>
             if action.keys.count > 0 {
                 let actionKey: String = (Array(action.keys) as! [String])[0]
                 cell.textLabel?.text = actionKey
                 var actionString = ""
-                if let actionDict = action[actionKey] as? Dictionary<String, AnyObject> {
+                if let actionDict = action[actionKey] as? Dictionary<String, Any> {
                     for (key, value) in actionDict {
                         actionString = "\(key): \(value) "
                     }
@@ -109,9 +109,9 @@ class CommandViewController: KiiBaseTableViewController {
         }else {
             sections.append(SectionStruct(headerTitle: "Schema", items: [schema!.name]))
             sections.append(SectionStruct(headerTitle: "Version", items: [schema!.version]))
-            sections.append(SectionStruct(headerTitle: "Actions", items: [AnyObject]()))
-            sections.append(SectionStruct(headerTitle: "ActionResults", items: [AnyObject]()))
-            sections.append(SectionStruct(headerTitle: "State", items: [AnyObject]()))
+            sections.append(SectionStruct(headerTitle: "Actions", items: [Any]()))
+            sections.append(SectionStruct(headerTitle: "ActionResults", items: [Any]()))
+            sections.append(SectionStruct(headerTitle: "State", items: [Any]()))
         }
 
     }

--- a/SampleProject/IoTSchema.swift
+++ b/SampleProject/IoTSchema.swift
@@ -53,11 +53,11 @@ struct ActionStruct {
             return nil
         }
 
-        let actionNameKey = Array(actionDict.keys)[0]
+        let actionNameKey = (Array(actionDict.keys) as! [String])[0]
 
         if actionSchema.name == actionNameKey {
             if let statusDict = actionDict[actionNameKey] as? Dictionary<String, AnyObject> {
-                let statusNameKey = Array(statusDict.keys)[0]
+                let statusNameKey = (Array(statusDict.keys) as! [String])[0]
                 if actionSchema.status.name == statusNameKey {
                     self.value = statusDict[statusNameKey]
                 }else{

--- a/SampleProject/IoTSchema.swift
+++ b/SampleProject/IoTSchema.swift
@@ -33,20 +33,20 @@ enum StatusType: String{
 
 struct ActionStruct {
     let actionSchema: ActionSchema!
-    var value: AnyObject!
+    var value: Any!
 
     // the return Ditionary will be like: ["actionName": ["requiredStatus": value] ], where value can be Bool, Int or Double. ie. ["TurnPower": ["power": true]]
-    func getActionDict() -> Dictionary<String, AnyObject> {
-        let actionDict: Dictionary<String, AnyObject> = [actionSchema.name: [actionSchema.status.name: value]]
+    func getActionDict() -> Dictionary<String, Any> {
+        let actionDict: Dictionary<String, Any> = [actionSchema.name: [actionSchema.status.name: value]]
         return actionDict
     }
 
-    init(actionSchema: ActionSchema, value: AnyObject) {
+    init(actionSchema: ActionSchema, value: Any) {
         self.actionSchema = actionSchema
         self.value = value
     }
 
-    init?(actionSchema: ActionSchema, actionDict: Dictionary<String, AnyObject>) {
+    init?(actionSchema: ActionSchema, actionDict: Dictionary<String, Any>) {
         self.actionSchema = actionSchema
 
         if actionDict.keys.count == 0 {
@@ -56,7 +56,7 @@ struct ActionStruct {
         let actionNameKey = (Array(actionDict.keys) as! [String])[0]
 
         if actionSchema.name == actionNameKey {
-            if let statusDict = actionDict[actionNameKey] as? Dictionary<String, AnyObject> {
+            if let statusDict = actionDict[actionNameKey] as? Dictionary<String, Any> {
                 let statusNameKey = (Array(statusDict.keys) as! [String])[0]
                 if actionSchema.status.name == statusNameKey {
                     self.value = statusDict[statusNameKey]
@@ -76,8 +76,8 @@ struct ActionStruct {
 class StatusSchema: NSObject, NSCoding {
     let name: String!
     let type: StatusType!
-    var minValue: AnyObject?
-    var maxValue: AnyObject?
+    var minValue: Any?
+    var maxValue: Any?
 
     func encode(with aCoder: NSCoder) {
         aCoder.encode(self.name, forKey: "name")
@@ -94,7 +94,7 @@ class StatusSchema: NSObject, NSCoding {
         self.maxValue = aDecoder.decodeObject(forKey: "maxValue")
     }
 
-    init(name: String, type: StatusType, minValue: AnyObject?, maxValue: AnyObject?) {
+    init(name: String, type: StatusType, minValue: Any?, maxValue: Any?) {
         self.name = name
         self.type = type
         self.minValue = minValue
@@ -158,7 +158,7 @@ class IoTSchema: NSObject,NSCoding {
         statusSchemaDict[statusName] = StatusSchema(name: statusName, type: statusType, minValue: nil, maxValue: nil)
     }
 
-    func addStatus(_ statusName: String, statusType: StatusType, minValue: AnyObject?, maxvalue: AnyObject?) {
+    func addStatus(_ statusName: String, statusType: StatusType, minValue: Any?, maxvalue: Any?) {
         statusSchemaDict[statusName] = StatusSchema(name: statusName, type: statusType, minValue: minValue, maxValue: maxvalue)
     }
 

--- a/SampleProject/ServerCodeTriggerDetailViewController.swift
+++ b/SampleProject/ServerCodeTriggerDetailViewController.swift
@@ -100,7 +100,7 @@ class ServerCodeTriggerDetailViewController: KiiBaseTableViewController,
 
     func saveTriggerOptions(_ title: String?,
                             description: String?,
-                            metadata: Dictionary<String, AnyObject>?)
+                            metadata: Dictionary<String, Any>?)
     {
         if title != nil || description != nil || metadata != nil {
             self.options = TriggerOptions(title: title,

--- a/SampleProject/TriggerCommandEditViewController.swift
+++ b/SampleProject/TriggerCommandEditViewController.swift
@@ -12,11 +12,11 @@ import ThingIFSDK
 protocol TriggerCommandEditViewControllerDelegate {
     func saveCommands(_ schemaName: String,
                       schemaVersion: Int,
-                      actions: [Dictionary<String, AnyObject>],
+                      actions: [Dictionary<String, Any>],
                       targetID: String?,
                       title: String?,
                       commandDescription: String?,
-                      metadata: Dictionary<String, AnyObject>?)
+                      metadata: Dictionary<String, Any>?)
 }
 
 class TriggerCommandEditViewController: CommandEditViewController {
@@ -119,7 +119,7 @@ class TriggerCommandEditViewController: CommandEditViewController {
 
     @IBAction func tapSaveCommand(_ sender: AnyObject) {
         // generate actions array
-        var actions = [Dictionary<String, AnyObject>]()
+        var actions = [Dictionary<String, Any>]()
         if let actionsItems = sections[2].items {
             for actionItem in actionsItems {
                 if let actionCellData = actionItem as? ActionStruct {
@@ -154,11 +154,11 @@ class TriggerCommandEditViewController: CommandEditViewController {
         } else {
             description = nil
         }
-        let metadata: Dictionary<String, AnyObject>?
+        let metadata: Dictionary<String, Any>?
         if let text = (self.view.viewWithTag(205) as? UITextView)?.text {
             metadata = try? JSONSerialization.jsonObject(
               with: text.data(using: String.Encoding.utf8)!,
-              options: .mutableContainers) as! Dictionary<String, AnyObject>
+              options: .mutableContainers) as! Dictionary<String, Any>
         } else {
             metadata = nil
         }

--- a/SampleProject/TriggerOptionsViewController.swift
+++ b/SampleProject/TriggerOptionsViewController.swift
@@ -12,7 +12,7 @@ import ThingIFSDK
 protocol TriggerOptionsViewControllerDelegate {
     func saveTriggerOptions(_ title: String?,
                             description: String?,
-                            metadata: Dictionary<String, AnyObject>?)
+                            metadata: Dictionary<String, Any>?)
 }
 
 class TriggerOptionsViewController: KiiBaseTableViewController {
@@ -41,11 +41,11 @@ class TriggerOptionsViewController: KiiBaseTableViewController {
     }
 
     @IBAction func tapSaveTriggerOptions(_ sender: AnyObject) {
-        var metadata: Dictionary<String, AnyObject>?
+        var metadata: Dictionary<String, Any>?
         if let text = self.metadataField.text {
             metadata = try? JSONSerialization.jsonObject(
               with: text.data(using: String.Encoding.utf8)!,
-              options: .mutableContainers) as! Dictionary<String, AnyObject>
+              options: .mutableContainers) as! Dictionary<String, Any>
         } else {
             metadata = nil
         }

--- a/SampleProject/TriggerServerCodeEditViewController.swift
+++ b/SampleProject/TriggerServerCodeEditViewController.swift
@@ -7,7 +7,7 @@ protocol TriggerServerCodeEditViewControllerDelegate {
 
 struct ParameterStruct {
     var key: String
-    var value: AnyObject
+    var value: Any
     var isString: Bool {
         return value is NSString
     }
@@ -168,9 +168,9 @@ class TriggerServerCodeEditViewController: KiiBaseTableViewController, TriggerSe
     }
 
     fileprivate static func parametersToDictionary(
-      _ parameters: [ParameterStruct]) -> Dictionary<String, AnyObject>
+      _ parameters: [ParameterStruct]) -> Dictionary<String, Any>
     {
-        var retval: Dictionary<String, AnyObject> = [ : ]
+        var retval: Dictionary<String, Any> = [ : ]
         for parameter in parameters {
             retval[parameter.key] = parameter.value
         }

--- a/SampleProject/TriggerServerCodeParameterEditViewController.swift
+++ b/SampleProject/TriggerServerCodeParameterEditViewController.swift
@@ -63,11 +63,11 @@ class TriggerServerCodeParameterEditViewController: KiiBaseTableViewController, 
                     if parameters[rowIndex - 1].isInt {
                         parameters[rowIndex - 1].value = Int(textFieldValue.text!)!
                     } else {
-                        parameters[rowIndex - 1].value = textFieldValue.text! as AnyObject
+                        parameters[rowIndex - 1].value = textFieldValue.text!
                     }
                 }
                 if let switchValue = cell?.viewWithTag(201) as? UISwitch {
-                    parameters[rowIndex - 1].value = switchValue.isOn as AnyObject
+                    parameters[rowIndex - 1].value = switchValue.isOn
                 }
             }
         }
@@ -81,11 +81,11 @@ class TriggerServerCodeParameterEditViewController: KiiBaseTableViewController, 
     var selectedType = 0
     func selectAction(_ sender: UIButton){
         if selectedType == 0 {
-            parameters.append(ParameterStruct(key: "", value: "" as AnyObject))
+            parameters.append(ParameterStruct(key: "", value: ""))
         } else if selectedType == 1 {
-            parameters.append(ParameterStruct(key: "", value: 0 as AnyObject))
+            parameters.append(ParameterStruct(key: "", value: 0))
         } else {
-            parameters.append(ParameterStruct(key: "", value: true as AnyObject))
+            parameters.append(ParameterStruct(key: "", value: true))
         }
         tableView.beginUpdates()
         tableView.insertRows(at: [


### PR DESCRIPTION
This PR is not buildable. This is a part of migration swift 3.0

This PR contains following changes:

  * Array(dict.keys)[0] cause build crash (be42b56)

    To get key of dictionary, `Array(dict.keys)[0]` is used but this cause crash of build. As workaround, `(Array(dict.keys) as! [String])[0]` is used.
  * AnyObject is changed to Any (1579aef)

Related PR: #31 
